### PR TITLE
1105.java

### DIFF
--- a/boj/greedy/1105.java
+++ b/boj/greedy/1105.java
@@ -1,0 +1,33 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+// The main method must be in a class named "Main".
+class Main {
+    static String L, R;
+    static int cnt = 0;
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        L = st.nextToken();
+        R = st.nextToken();
+
+        if(L.length() != R.length()) System.out.println(0);
+        else {
+            for(int i = 0 ; i < L.length() ; i++) {
+                if(L.charAt(i) == R.charAt(i)) { 
+                    if(L.charAt(i) == '8') {
+                        cnt++;
+                    }
+                } else {
+                    break;
+                }
+            } 
+            System.out.println(cnt);
+        }
+
+        
+
+    }
+}


### PR DESCRIPTION
처음에는 무작정 for문으로 브루트포스 (L ~ R까지) 했으나 역시 예상한대로 시간 초과가 떴다. 
조금만 생각해보니 굳이 모든 수를 검사할 필요 없이 ‘8’이 언제 **반드시 들어가야하는지** 생각해보면 된다.

1. 자릿수가 다른 경우: 8이 굳이 들어갈 필요가 없으므로 답은 항상 0
2. 자릿수가 같은 경우: 10의 n승 자리에 L과 R 모두 8이 위치하면 8이 반드시 들어가야하는 경우이다. 
    
    다만, 맨 처음에는 코드를 `L.charAt(i) == ‘8’ && R.charAt(i) == ‘8’`로 작성하여 예외 케이스가 발생했다. (ex. 입력이 180 189 인 경우). `L.charAt(i)`와 `R.charAt(i)`가 같은 경우도 그냥 계속 for문을 진행해주어야 다음 자리에 8이 공통으로 왔을 때 `cnt++`해줄 수 있다.